### PR TITLE
Remove "echo no callback found for column"

### DIFF
--- a/includes/admin/companies/company.php
+++ b/includes/admin/companies/company.php
@@ -128,7 +128,6 @@ function kbs_set_company_column_data( $column_name, $post_id ) {
 			break;
 
 		default:
-			echo __( 'No callback found for post column', 'kb-support' );
 			break;
 	}
 

--- a/includes/admin/tickets/tickets.php
+++ b/includes/admin/tickets/tickets.php
@@ -202,7 +202,6 @@ function kbs_set_kbs_ticket_column_data( $column_name, $post_id ) {
 			break;
 
 		default:
-			echo __( 'No callback found for post column', 'kb-support' );
 			break;
 	}
 } // kbs_set_kbs_ticket_column_data


### PR DESCRIPTION
This prevents me from adding a column to the list table.

It doesn't take into account that I'm already hooked to WordPress core `manage_kbs_ticket_posts_custom_column` hook, and offers no alternative, and no easy way to remove the message (besides filtering `get_text`) since it's inside a switch statement. 

This problem is also in [article.php:149](https://github.com/WPChill/kb-support/blob/399103109030b7ebb8409cd416c82d0913261a71/includes/admin/article/article.php#L149).

Please keep with the native WordPress way of managing list tables.