### PR TITLE
Add is_numeric check

### DIFF
--- a/includes/admin/tickets/tickets.php
+++ b/includes/admin/tickets/tickets.php
@@ -770,7 +770,7 @@ add_action( 'pre_get_posts', 'kbs_filter_company_tickets' );
  * @return	void
  */
 function kbs_filter_agent_tickets( $query )	{
-	if ( ! is_admin() || 'kbs_ticket' != $query->get( 'post_type' ) || ! isset( $_GET['agent'] ) )	{
+	if ( ! is_admin() || 'kbs_ticket' != $query->get( 'post_type' ) || ! isset( $_GET['agent'] ) || ! is_numeric( $_GET['agent'] ) ) {
 		return;
 	}
 


### PR DESCRIPTION
On a fresh install with one ticket, attempting to filter by date without choosing an agent filter results in no results.

The problem is the string "All agents" is being added as a meta-query.

This fix adds a check `is_numeric( $_GET['agent'] )` before adding an Agent filter.