### PR TITLE
Ticket categories

### DIFF
--- a/includes/tickets/class-kbs-ticket.php
+++ b/includes/tickets/class-kbs-ticket.php
@@ -2223,7 +2223,7 @@ class KBS_Ticket {
 				}
 
 				if ( 'post_category' == $settings['mapping'] )	{
-					$value = is_array( $value ) ? $value : array( $value );
+					$value = is_array( $value ) ? $value : array();
 					$cats  = array();
 					foreach( $value as $category )	{
 						$term = get_term( $category );

--- a/includes/tickets/class-kbs-ticket.php
+++ b/includes/tickets/class-kbs-ticket.php
@@ -2227,7 +2227,7 @@ class KBS_Ticket {
 					$cats  = array();
 					foreach( $value as $category )	{
 						$term = get_term( $category );
-						if ( $term )	{
+						if ( is_object( $term ) && 'WP_Term' === get_class( $term ) ) {
 							$cats[] = $term->name;
 						} else	{
 							$cats[] = sprintf( esc_html__( 'Term %s no longer exists', 'kb-support' ), $category );


### PR DESCRIPTION
Fixed an issue where editing a ticket without a ticket category logged a PHP warning..

## Steps to reproduce:
1. On the backend, add a ticket category.
2. Edit the ticket submissions form.
3. Add a new field with the "Ticket Categories" type.
4. Update the form.
5. On the front end, log a support ticket.
6. Do not select a ticket category.
7. Submit the ticket.
8. On the backend, edit the ticket submitted in the previous step.
9. Click "View submission data".

### Expected

- The ticket category should be empty.
- No PHP warnings.

### Actual

- The ticket category is empty.
- `PHP Warning:  Undefined property: WP_Error::$name in C:\WordPress\wp-content\plugins\kb-support\includes\tickets\class-kbs-ticket.php on line 2231`

## Cause

When there are no ticket categories in the form data, the value is an empty string instead of an empty array.
