### PR TITLE
Add `kbs_add_ticket()` array parameter type hinting

### DIFF
--- a/includes/tickets/ticket-functions.php
+++ b/includes/tickets/ticket-functions.php
@@ -701,7 +701,7 @@ function kbs_add_ticket( $ticket_data )	{
 	$ticket->ip               = kbs_get_ip();
 	$ticket->sla_respond      = kbs_calculate_sla_target_response();
 	$ticket->sla_resolve      = kbs_calculate_sla_target_resolution();
-	$ticket->new_files        = $ticket_data['attachments'];
+	$ticket->new_files        = $attachments;
 	$ticket->form_data        = ! empty( $ticket_data['form_data'] ) ? $ticket_data['form_data'] : array();
 	$ticket->privacy_accepted = isset( $ticket_data['privacy_accepted'] ) ? $ticket_data['privacy_accepted'] : false;
 	$ticket->terms_agreed     = isset( $ticket_data['terms_agreed'] ) ? $ticket_data['terms_agreed'] : false;

--- a/includes/tickets/ticket-functions.php
+++ b/includes/tickets/ticket-functions.php
@@ -652,8 +652,25 @@ function kbs_get_ticket_log_sources()	{
  * Adds a new ticket.
  *
  * @since	1.0
- * @param	arr		$ticket_data	Ticket data.
- * @return	mixed	Ticket ID on success, false on failure.
+ * @param	array{
+ *     			post_title:string,
+ *     			post_content:string,
+ *     			user_email:string,
+ *     			post_category?:int,
+ *     			status?:string,
+ *     			department?:int,
+ *     			agent_id?:int,
+ *     			attachments?:array|mixed,
+ *     			user_info:array{id?:int,first_name?:string,email?:string,last_name?:string},
+ *     			participants?:array<string>,
+ *     			privacy_accepted:false|string,
+ *     			terms_agreed:false|string,
+ *     			form_data?:array,
+ *     			source:string,
+ *     			submission_origin?:string,
+ *     			post_date?:string
+ * 		} $ticket_data	Ticket data.
+ * @return	int|false	Ticket ID on success, false on failure.
  */
 function kbs_add_ticket( $ticket_data )	{
 	if ( ! empty( $ticket_data['attachments'] ) && ! is_array( $ticket_data['attachments'] ) )	{


### PR DESCRIPTION
Also fix a bug where the filter result for `$attachments` was being discarded.

https://github.com/WPChill/kb-support/blob/dd64e3d7024d63f96c1a6ce95a315442fb3fd566/includes/tickets/ticket-functions.php#L671

https://github.com/WPChill/kb-support/blob/dd64e3d7024d63f96c1a6ce95a315442fb3fd566/includes/tickets/ticket-functions.php#L705