### PR TITLE
Do not execute role install every request on single sites

### DIFF
--- a/includes/install.php
+++ b/includes/install.php
@@ -373,6 +373,10 @@ add_action( 'admin_init', 'kbs_after_install' );
  */
 function kbs_install_roles_on_network() {
 
+	if( ! is_multisite() ) {
+		return;
+	}
+
 	global $wp_roles;
 
 	if ( ! is_object( $wp_roles ) ) {


### PR DESCRIPTION
This stops the role install running on every single `admin_init`. 

It was already run in single-sites inside `kbs_run_install()`.